### PR TITLE
chore: remove unnecessary eslint ignore

### DIFF
--- a/src/multi-region-cache-writer-client.ts
+++ b/src/multi-region-cache-writer-client.ts
@@ -58,8 +58,6 @@ export class MultiRegionCacheWriterClient
     try {
       const responses: RegionalCacheSet.Response[] = await Promise.all(
         this.regions.map(region =>
-          // TODO: debug why this is not working
-          // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
           this.clients[region].set(cacheName, key, value, options)
         )
       );


### PR DESCRIPTION
This ignore is no longer necessary after fixing the project name.
